### PR TITLE
Add COEP, CORP, and COOP headers

### DIFF
--- a/shcheck.py
+++ b/shcheck.py
@@ -78,7 +78,10 @@ sec_headers = {
     'X-Permitted-Cross-Domain-Policies': 'warning',
     'Referrer-Policy': 'warning',
     'Expect-CT': 'warning',
-    'Permissions-Policy': 'warning'
+    'Permissions-Policy': 'warning',
+    'Cross-Origin-Embedder-Policy': 'warning',
+    'Cross-Origin-Resource-Policy': 'warning',
+    'Cross-Origin-Opener-Policy': 'warning'
 }
 
 information_headers = {


### PR DESCRIPTION
These are relatively new headers that are mostly used to prevent [XS-Leaks](https://xsleaks.com/).
Further information: https://web.dev/why-coop-coep/ and https://medium.com/@terjanq/massive-xs-search-over-multiple-google-products-416e50dd2ec6