### PR TITLE
Fix missing comma in cache_headers and Upgrade-Insecure-Requests type

### DIFF
--- a/shcheck/shcheck.py
+++ b/shcheck/shcheck.py
@@ -66,7 +66,7 @@ client_headers = {
     'Accept': 'text/html,application/xhtml+xml,\
  application/xml;q=0.9,*/*;q=0.8',
     'Accept-Language': 'en-US;q=0.8,en;q=0.3',
-    'Upgrade-Insecure-Requests': 1
+    'Upgrade-Insecure-Requests': '1'
  }
 
 
@@ -96,7 +96,7 @@ information_headers = {
 cache_headers = {
     'Cache-Control',
     'Pragma',
-    'Last-Modified'
+    'Last-Modified',
     'Expires',
     'ETag'
 }


### PR DESCRIPTION
- Add missing comma between 'Last-Modified' and 'Expires' in cache_headers set literal; without it Python silently concatenated them into the single string 'Last-ModifiedExpires', making Last-Modified undetectable.
- Change Upgrade-Insecure-Requests header value from int 1 to string '1'; HTTP header values must be strings.