### PR TITLE
Fix HSTS non-HTTPS check never matching

### DIFF
--- a/shcheck/shcheck.py
+++ b/shcheck/shcheck.py
@@ -393,7 +393,7 @@ def main():
                 unsafe += 1
                 json_results["missing"].append(safeh)
                 # HSTS works obviously only on HTTPS
-                if safeh == 'Strict-Transport-Security'.lower() and not is_https(rUrl):
+                if lsafeh == 'Strict-Transport-Security'.lower() and not is_https(rUrl):
                     unsafe -= 1
                     json_results["missing"].remove(safeh)
                     continue


### PR DESCRIPTION
safeh holds the original cased key ('Strict-Transport-Security') but was compared against 'Strict-Transport-Security'.lower(), making the condition always False. Use lsafeh instead, consistent with every other header comparison in the loop.