### PR TITLE
Fix SyntaxWarning from return in finally block (PEP 765)

### DIFF
--- a/shcheck/shcheck.py
+++ b/shcheck/shcheck.py
@@ -190,8 +190,7 @@ def normalize(target):
             target = 'http://' + target
     except (ValueError, socket.error):
         pass
-    finally:
-        return target
+    return target
 
 
 def print_error(target, e):


### PR DESCRIPTION
Python 3.14 raises SyntaxWarning for 'return' inside a 'finally' block as it can mask exceptions and obscures control flow. The finally block in normalize() was used solely to return target unconditionally, which is equivalent to a plain return after the try/except.

Fixes #56