### PR TITLE
Update User-Agent to modern Chrome string

### DIFF
--- a/shcheck/shcheck.py
+++ b/shcheck/shcheck.py
@@ -61,8 +61,8 @@ def log(string):
 
 # Client headers to send to the server during the request.
 client_headers = {
-    'User-Agent': 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:53.0)\
- Gecko/20100101 Firefox/53.0',
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)\
+ AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
     'Accept': 'text/html,application/xhtml+xml,\
  application/xml;q=0.9,*/*;q=0.8',
     'Accept-Language': 'en-US;q=0.8,en;q=0.3',


### PR DESCRIPTION
The previous User-Agent (Firefox 53, 2017) caused some servers including Google to omit security headers like Strict-Transport-Security from their responses, producing false negatives. Updating to a current Chrome UA ensures servers respond with the same headers a real browser would receive.

Fixes #52