### PR TITLE
Prepend https:// to bare domain names in normalize()

### DIFF
--- a/shcheck/shcheck.py
+++ b/shcheck/shcheck.py
@@ -189,7 +189,8 @@ def normalize(target):
         if (socket.inet_aton(target)):
             target = 'http://' + target
     except (ValueError, socket.error):
-        pass
+        if not target.startswith(('http://', 'https://')):
+            target = 'https://' + target
     return target
 
 

--- a/tests/test_shcheck.py
+++ b/tests/test_shcheck.py
@@ -113,6 +113,12 @@ def test_append_port_without_trailing_slash():
 def test_normalize_bare_ip_adds_http():
     assert shcheck.normalize('192.168.1.1') == 'http://192.168.1.1'
 
+def test_normalize_bare_domain_adds_https():
+    assert shcheck.normalize('github.com') == 'https://github.com'
+
+def test_normalize_bare_domain_with_path_adds_https():
+    assert shcheck.normalize('github.com/santoru/shcheck') == 'https://github.com/santoru/shcheck'
+
 def test_normalize_https_url_unchanged():
     assert shcheck.normalize('https://example.com') == 'https://example.com'
 


### PR DESCRIPTION
Bare domain inputs like 'github.com' would pass through normalize() unchanged (only bare IPs were handled), causing urllib to raise ValueError: unknown url type. Now any target without an http:// or https:// scheme gets https:// prepended, matching browser behaviour.

Fixes #57