### PR TITLE
Clean up no-op global, misleading if, string literal .lower(), append…

### DIFF
--- a/shcheck/shcheck.py
+++ b/shcheck/shcheck.py
@@ -25,7 +25,6 @@ import http.client
 import socket
 import sys
 import ssl
-import os
 import json
 from optparse import OptionParser
 
@@ -136,9 +135,9 @@ def parse_headers(hdrs):
 
 
 def append_port(target, port):
-    return target[:-1] + ':' + port + '/' \
-        if target[-1:] == '/' \
-        else target + ':' + port + '/'
+    if target[-1:] == '/':
+        return target[:-1] + ':' + port + '/'
+    return target + ':' + port
 
 
 def build_opener(proxy, ssldisabled, nofollow=False):
@@ -186,8 +185,8 @@ def build_opener(proxy, ssldisabled, nofollow=False):
 
 def normalize(target):
     try:
-        if (socket.inet_aton(target)):
-            target = 'http://' + target
+        socket.inet_aton(target)
+        target = 'http://' + target
     except (ValueError, socket.error):
         if not target.startswith(('http://', 'https://')):
             target = 'https://' + target
@@ -295,11 +294,6 @@ def main():
     hfile = options.hfile
     json_output = options.json_output
 
-    # Disabling printing if json output is requested
-    if json_output:
-        global json_headers
-        sys.stdout = open(os.devnull, 'w')
-
     banner()
     # Set a custom port if provided
     if cookie is not None:
@@ -350,7 +344,7 @@ def main():
         target_sec_headers = dict(sec_headers)
         if "content-security-policy" in headers.keys() and "frame-ancestors" in headers.get("content-security-policy").lower():
             target_sec_headers.pop("X-Frame-Options", None)
-            headers.pop("X-Frame-Options".lower(), None)
+            headers.pop('x-frame-options', None)
 
         for safeh in target_sec_headers:
             lsafeh = safeh.lower()
@@ -361,25 +355,25 @@ def main():
                 # Taking care of special headers that could have bad values
 
                 # Parse CSP headers
-                if lsafeh == 'Content-Security-Policy'.lower():
+                if lsafeh == 'content-security-policy':
                     log("[*] Header {} is present!".format(
                             colorize(safeh, 'ok')))
                     parse_csp(headers.get(lsafeh))
 
                 # X-XSS-Protection Should be enabled
-                elif lsafeh == 'X-XSS-Protection'.lower() and headers.get(lsafeh) == '0':
+                elif lsafeh == 'x-xss-protection' and headers.get(lsafeh) == '0':
                     log("[*] Header {} is present! (Value: {})".format(
                             colorize(safeh, 'ok'),
                             colorize(headers.get(lsafeh), 'warning')))
 
                 # unsafe-url policy is more insecure compared to the default/unset value
-                elif lsafeh == 'Referrer-Policy'.lower() and headers.get(lsafeh) == 'unsafe-url':
+                elif lsafeh == 'referrer-policy' and headers.get(lsafeh) == 'unsafe-url':
                     log("[!] Insecure header {} is set! (Value: {})".format(
                             colorize(safeh, 'warning'),
                             colorize(headers.get(lsafeh), 'error')))
 
                 # check for max-age=0 in HSTS
-                elif lsafeh == 'Strict-Transport-Security'.lower() and "max-age=0" in headers.get(lsafeh):
+                elif lsafeh == 'strict-transport-security' and "max-age=0" in headers.get(lsafeh):
                     log("[!] Insecure header {} is set! (Value: {})".format(
                             colorize(safeh, 'warning'),
                             colorize(headers.get(lsafeh), 'error')))
@@ -393,7 +387,7 @@ def main():
                 unsafe += 1
                 json_results["missing"].append(safeh)
                 # HSTS works obviously only on HTTPS
-                if lsafeh == 'Strict-Transport-Security'.lower() and not is_https(rUrl):
+                if lsafeh == 'strict-transport-security' and not is_https(rUrl):
                     unsafe -= 1
                     json_results["missing"].remove(safeh)
                     continue
@@ -441,7 +435,6 @@ header {} is present! (Value: {})".format(
         json_out.update(json_headers)
 
     if json_output:
-        sys.stdout = sys.__stdout__
         print(json.dumps(json_out))
 
 

--- a/tests/test_shcheck.py
+++ b/tests/test_shcheck.py
@@ -52,14 +52,10 @@ def _run_json(extra_args, headers, url):
     """Run main() with -j and return parsed JSON output."""
     mock = _mock_response(headers, url)
     captured = io.StringIO()
-    old_stdout = sys.stdout
-    try:
-        with patch('sys.argv', ['shcheck.py', '-j'] + extra_args + [url]), \
-             patch.object(sys, '__stdout__', captured), \
-             patch('urllib.request.urlopen', return_value=mock):
-            shcheck.main()
-    finally:
-        sys.stdout = old_stdout
+    with patch('sys.argv', ['shcheck.py', '-j'] + extra_args + [url]), \
+         patch('sys.stdout', captured), \
+         patch('urllib.request.urlopen', return_value=mock):
+        shcheck.main()
     return json.loads(captured.getvalue())
 
 
@@ -104,7 +100,7 @@ def test_append_port_with_trailing_slash():
     assert shcheck.append_port('http://example.com/', '8080') == 'http://example.com:8080/'
 
 def test_append_port_without_trailing_slash():
-    assert shcheck.append_port('http://example.com', '8080') == 'http://example.com:8080/'
+    assert shcheck.append_port('http://example.com', '8080') == 'http://example.com:8080'
 
 
 # ---------------------------------------------------------------------------
@@ -199,14 +195,10 @@ def test_sec_headers_not_mutated_across_targets():
     mock2 = _mock_response(headers_without_xfo, second_url)
 
     captured = io.StringIO()
-    old_stdout = sys.stdout
-    try:
-        with patch('sys.argv', ['shcheck.py', '-j', HTTPS_URL, second_url]), \
-             patch.object(sys, '__stdout__', captured), \
-             patch('urllib.request.urlopen', side_effect=[mock1, mock2]):
-            shcheck.main()
-    finally:
-        sys.stdout = old_stdout
+    with patch('sys.argv', ['shcheck.py', '-j', HTTPS_URL, second_url]), \
+         patch('sys.stdout', captured), \
+         patch('urllib.request.urlopen', side_effect=[mock1, mock2]):
+        shcheck.main()
 
     data = json.loads(captured.getvalue())
     # X-Frame-Options must still be checked on the second target
@@ -368,14 +360,10 @@ def _run_json_multi(extra_args, targets_and_headers):
     mocks = [_mock_response(hdrs, url) for url, hdrs in targets_and_headers]
     urls = [url for url, _ in targets_and_headers]
     captured = io.StringIO()
-    old_stdout = sys.stdout
-    try:
-        with patch('sys.argv', ['shcheck.py', '-j'] + extra_args + urls), \
-             patch.object(sys, '__stdout__', captured), \
-             patch('urllib.request.urlopen', side_effect=mocks):
-            shcheck.main()
-    finally:
-        sys.stdout = old_stdout
+    with patch('sys.argv', ['shcheck.py', '-j'] + extra_args + urls), \
+         patch('sys.stdout', captured), \
+         patch('urllib.request.urlopen', side_effect=mocks):
+        shcheck.main()
     return json.loads(captured.getvalue())
 
 
@@ -416,36 +404,24 @@ def test_bug1_caching_preserved_per_target():
 # Bug #2 — print() calls in check_target are swallowed by stdout redirect under -j
 
 def test_bug2_unknown_protocol_error_visible_in_json_mode():
-    """'Unknown protocol' error must reach stderr even when -j redirects stdout
-    to devnull. Currently the message is swallowed."""
+    """'Unknown protocol' error must reach stderr even in -j mode."""
     captured_stderr = io.StringIO()
-    captured_json = io.StringIO()
-    old_stdout = sys.stdout
-    try:
-        with patch('sys.argv', ['shcheck.py', '-j', HTTPS_URL]), \
-             patch.object(sys, '__stdout__', captured_json), \
-             patch('sys.stderr', captured_stderr), \
-             patch('urllib.request.urlopen',
-                   side_effect=http.client.UnknownProtocol('HTTP/2')):
-            shcheck.main()
-    finally:
-        sys.stdout = old_stdout
+    with patch('sys.argv', ['shcheck.py', '-j', HTTPS_URL]), \
+         patch('sys.stdout', io.StringIO()), \
+         patch('sys.stderr', captured_stderr), \
+         patch('urllib.request.urlopen',
+               side_effect=http.client.UnknownProtocol('HTTP/2')):
+        shcheck.main()
     assert 'Unknown protocol' in captured_stderr.getvalue()
 
 
 def test_bug2_no_response_error_visible_in_json_mode():
-    """'Couldn't read a response from server.' must reach stderr even when -j
-    redirects stdout to devnull. Currently the message is swallowed."""
+    """'Couldn't read a response from server.' must reach stderr even in -j mode."""
     captured_stderr = io.StringIO()
-    captured_json = io.StringIO()
-    old_stdout = sys.stdout
-    try:
-        with patch('sys.argv', ['shcheck.py', '-j', HTTPS_URL]), \
-             patch.object(sys, '__stdout__', captured_json), \
-             patch('sys.stderr', captured_stderr), \
-             patch('urllib.request.urlopen',
-                   side_effect=http.client.UnknownProtocol('HTTP/2')):
-            shcheck.main()
-    finally:
-        sys.stdout = old_stdout
+    with patch('sys.argv', ['shcheck.py', '-j', HTTPS_URL]), \
+         patch('sys.stdout', io.StringIO()), \
+         patch('sys.stderr', captured_stderr), \
+         patch('urllib.request.urlopen',
+               side_effect=http.client.UnknownProtocol('HTTP/2')):
+        shcheck.main()
     assert "Couldn't read a response from server." in captured_stderr.getvalue()


### PR DESCRIPTION
…_port slash, stdout redirect

#4 Remove no-op 'global json_headers' declaration from main(); json_headers
   is a loop-local variable and the global declaration had no effect.

#5 Remove misleading 'if' in normalize(): socket.inet_aton() always returns
   truthy bytes when it doesn't raise, so the condition was never False.

#6 Replace runtime .lower() calls on string literals with their lowercase
   equivalents ('Content-Security-Policy'.lower() -> 'content-security-policy'
   etc.) in the header-checking loop and frame-ancestors pop.

#7 append_port no longer adds a trailing slash when the input URL didn't have
   one (http://example.com:8080 instead of http://example.com:8080/).

#8 Remove the sys.stdout -> devnull redirect under -j: log() already
   suppresses output when json_output=True, making the redirect redundant.
   Removing it also eliminates the file handle leak and lets test helpers
   use a simple patch('sys.stdout') instead of the __stdout__/finally dance.
   Drop now-unused 'import os'.