### PR TITLE
Refactor: remove dead code and minor style cleanup, bump to 1.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,16 +20,10 @@
 from setuptools import setup
 
 PACKAGE_NAME = "shcheck"
-VERSION = "1.6.7"
+VERSION = "1.7"
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
-
-
-def parse_requirements(filename):
-    """Load requirements from a pip requirements file."""
-    lineiter = (line.strip() for line in open(filename))
-    return [line for line in lineiter if line and not line.startswith("#")]
 
 
 if __name__ == "__main__":

--- a/shcheck.py
+++ b/shcheck.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
 from shcheck import shcheck
 
 if __name__ == "__main__":

--- a/shcheck/shcheck.py
+++ b/shcheck/shcheck.py
@@ -20,7 +20,6 @@
 import urllib.request
 import urllib.error
 import urllib.parse
-import urllib.response
 import http.client
 import socket
 import sys
@@ -121,7 +120,7 @@ def colorize(string, alert):
 
 
 def parse_headers(hdrs):
-    return dict((x.lower(), y) for x, y in hdrs)
+    return {x.lower(): y for x, y in hdrs}
 
 
 def append_port(target, port):
@@ -370,13 +369,13 @@ def main():
 
         log("[*] Effective URL: {}".format(colorize(rUrl, 'info')))
         headers = parse_headers(response.getheaders())
-        json_headers[f"{rUrl}"] = json_results
+        json_headers[rUrl] = json_results
         json_results["present"] = {}
         json_results["missing"] = []
 
         # Before parsing, remove X-Frame-Options if there's CSP with frame-ancestors directive
         target_sec_headers = dict(sec_headers)
-        if "content-security-policy" in headers.keys() and "frame-ancestors" in headers.get("content-security-policy").lower():
+        if "content-security-policy" in headers and "frame-ancestors" in headers.get("content-security-policy").lower():
             target_sec_headers.pop("X-Frame-Options", None)
             headers.pop('x-frame-options', None)
 


### PR DESCRIPTION
- Bump version to 1.7
- Remove unused imports: urllib.response (shcheck.py), sys (shcheck.py root)
- Remove never-called parse_requirements() from setup.py
- Replace dict(generator) with dict comprehension in parse_headers
- Remove redundant f-string and .keys() calls